### PR TITLE
Disable webgl2 due to the non support of the OES_texute_float extention

### DIFF
--- a/tessTutorial/view.js
+++ b/tessTutorial/view.js
@@ -257,7 +257,7 @@ $(function(){
     var canvas = $("#main").get(0);
 
     // initialize WebGL
-    $.each(["webgl2", "experimental-webgl2", "webgl", "experimental-webgl",
+    $.each([ "webgl", "experimental-webgl",
             "webkit-3d", "moz-webgl"], function(i, name){
         try {
             gl = canvas.getContext(name);


### PR DESCRIPTION
The current version of your sample does not work on the WebGS2 supported web browser.
I know you might have a better idea to make it work, but I would notice it to you.